### PR TITLE
Fix mediaEncoding error

### DIFF
--- a/src/fetch/getEvents.ts
+++ b/src/fetch/getEvents.ts
@@ -79,7 +79,7 @@ export const getTokenImage = async (
         "Content-Type": "application/json",
       }
     );
-    return events.token.token.image.mediaEncoding.poster;
+    return events.token.token?.image?.mediaEncoding?.poster;
   } catch (error) {
     console.log(error);
     return undefined;


### PR DESCRIPTION
Ran across the error below when running the bot for mfersbuildersdao. created a fix to get around this error so that our bot doesn't come down

```
TypeError: Cannot read properties of null (reading 'mediaEncoding')
```